### PR TITLE
docs: update example.md to match current API

### DIFF
--- a/example/example.md
+++ b/example/example.md
@@ -1,44 +1,46 @@
 # Dart Example
 
-Example dart app, default values from original Adhanjs.
+Example dart app showing how to use adhan_dart.
 
-```
+```dart
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:adhan_dart/adhan_dart.dart';
 
-main() {
+void main() {
   tz.initializeTimeZones();
   final location = tz.getLocation('America/New_York');
 
   // Definitions
   DateTime date = tz.TZDateTime.from(DateTime.now(), location);
-  Coordinates coordinates = Coordinates(35.78056, -78.6389);
+  Coordinates coordinates = const Coordinates(35.78056, -78.6389);
 
   // Parameters
-  CalculationParameters params = CalculationMethod.MuslimWorldLeague();
-  params.madhab = Madhab.Hanafi;
-  PrayerTimes prayerTimes =
-      PrayerTimes(coordinates: coordinates, date: date, calculationParameters: params, precision: true);
+  CalculationParameters params = CalculationMethodParameters.muslimWorldLeague()
+    ..madhab = Madhab.hanafi;
+  PrayerTimes prayerTimes = PrayerTimes(
+      coordinates: coordinates,
+      date: date,
+      calculationParameters: params,
+      precision: true);
 
-  // Prayer times
-  DateTime fajrTime = tz.TZDateTime.from(prayerTimes.fajr!, location);
-  DateTime sunriseTime = tz.TZDateTime.from(prayerTimes.sunrise!, location);
-  DateTime dhuhrTime = tz.TZDateTime.from(prayerTimes.dhuhr!, location);
-  DateTime asrTime = tz.TZDateTime.from(prayerTimes.asr!, location);
-  DateTime maghribTime = tz.TZDateTime.from(prayerTimes.maghrib!, location);
-  DateTime ishaTime = tz.TZDateTime.from(prayerTimes.isha!, location);
+  // Prayer times (convert from UTC to local timezone)
+  DateTime fajrTime = tz.TZDateTime.from(prayerTimes.fajr, location);
+  DateTime sunriseTime = tz.TZDateTime.from(prayerTimes.sunrise, location);
+  DateTime dhuhrTime = tz.TZDateTime.from(prayerTimes.dhuhr, location);
+  DateTime asrTime = tz.TZDateTime.from(prayerTimes.asr, location);
+  DateTime maghribTime = tz.TZDateTime.from(prayerTimes.maghrib, location);
+  DateTime ishaTime = tz.TZDateTime.from(prayerTimes.isha, location);
 
-  DateTime ishabeforeTime =
-      tz.TZDateTime.from(prayerTimes.ishabefore!, location);
-  DateTime fajrafterTime = tz.TZDateTime.from(prayerTimes.fajrafter!, location);
+  // Previous day's Isha and next day's Fajr
+  DateTime ishaBeforeTime = tz.TZDateTime.from(prayerTimes.ishaBefore, location);
+  DateTime fajrAfterTime = tz.TZDateTime.from(prayerTimes.fajrAfter, location);
 
   // Convenience Utilities
-  String current =
-      prayerTimes.currentPrayer(date: DateTime.now()); // date: date
-  DateTime? currentPrayerTime = prayerTimes.timeForPrayer(current);
-  String next = prayerTimes.nextPrayer();
-  DateTime? nextPrayerTime = prayerTimes.timeForPrayer(next);
+  Prayer current = prayerTimes.currentPrayer(date: DateTime.now());
+  DateTime currentPrayerTime = prayerTimes.timeForPrayer(current);
+  Prayer next = prayerTimes.nextPrayer();
+  DateTime nextPrayerTime = prayerTimes.timeForPrayer(next);
 
   // Sunnah Times
   SunnahTimes sunnahTimes = SunnahTimes(prayerTimes);
@@ -50,29 +52,64 @@ main() {
   // Qibla Direction
   var qiblaDirection = Qibla.qibla(coordinates);
 
-  print('***** Current Time');
-  print('local time:\t$date');
+  print('***** Prayer Times');
+  print('Fajr:    $fajrTime');
+  print('Sunrise: $sunriseTime');
+  print('Dhuhr:   $dhuhrTime');
+  print('Asr:     $asrTime');
+  print('Maghrib: $maghribTime');
+  print('Isha:    $ishaTime');
 
-  print('\n***** Prayer Times');
-  print('fajrTime:\t$fajrTime');
-  print('sunriseTime:\t$sunriseTime');
-  print('dhuhrTime:\t$dhuhrTime');
-  print('asrTime:\t$asrTime');
-  print('maghribTime:\t$maghribTime');
-  print('ishaTime:\t$ishaTime');
-
-  print('ishabeforeTime:\t$ishabeforeTime');
-  print('fajrafterTime:\t$fajrafterTime');
-
-  print('\n***** Convenience Utilities');
-  print('current:\t$current\t$currentPrayerTime');
-  print('next:   \t$next\t$nextPrayerTime');
+  print('\n***** Current & Next Prayer');
+  print('Current: $current at $currentPrayerTime');
+  print('Next:    $next at $nextPrayerTime');
 
   print('\n***** Sunnah Times');
-  print('middleOfTheNight:  \t$middleOfTheNight');
-  print('lastThirdOfTheNight:  \t$lastThirdOfTheNight');
+  print('Middle of the Night:    $middleOfTheNight');
+  print('Last Third of the Night: $lastThirdOfTheNight');
 
   print('\n***** Qibla Direction');
-  print('qibla:  \t$qiblaDirection');
+  print('Qibla: $qiblaDirection°');
 }
+```
+
+## Using without timezone package
+
+If you don't want to add the timezone package, you can use timezone offsets directly:
+
+```dart
+import 'package:adhan_dart/adhan_dart.dart';
+
+void main() {
+  Coordinates coordinates = const Coordinates(24.8607, 67.0011);
+  CalculationParameters params = CalculationMethodParameters.karachi();
+  PrayerTimes prayerTimes = PrayerTimes(
+      coordinates: coordinates,
+      date: DateTime.now(),
+      calculationParameters: params);
+
+  // Add your timezone offset manually (e.g., +5 hours for Pakistan)
+  int offsetMinutes = 5 * 60;
+  print('Fajr: ${prayerTimes.fajr.add(Duration(minutes: offsetMinutes))}');
+  print('Dhuhr: ${prayerTimes.dhuhr.add(Duration(minutes: offsetMinutes))}');
+}
+```
+
+## Available Calculation Methods
+
+```dart
+CalculationMethodParameters.muslimWorldLeague()
+CalculationMethodParameters.egyptian()
+CalculationMethodParameters.karachi()
+CalculationMethodParameters.ummAlQura()
+CalculationMethodParameters.dubai()
+CalculationMethodParameters.qatar()
+CalculationMethodParameters.kuwait()
+CalculationMethodParameters.moonsightingCommittee()
+CalculationMethodParameters.singapore()
+CalculationMethodParameters.turkiye()
+CalculationMethodParameters.tehran()
+CalculationMethodParameters.northAmerica()
+CalculationMethodParameters.morocco()
+CalculationMethodParameters.other() // for custom angles
 ```


### PR DESCRIPTION
## What

Updates `example/example.md` to use the current API instead of the pre-1.1.0 one.

## Why

I was trying to get started with the library and the example.md threw me off because it uses the old API — `CalculationMethod.MuslimWorldLeague()` instead of `CalculationMethodParameters.muslimWorldLeague()`, nullable bang operators, string return types for prayer names, and old property names like `ishabefore` instead of `ishaBefore`.

The actual runnable example in `example/lib/example.dart` is fine, but anyone reading the markdown file first would get confused.

## Changes

- Updated all API calls to match current v1.2.0
- Added a section showing usage without the timezone package (since the README mentions it's only needed for tests)
- Added a quick reference list of all available calculation methods

No code changes — docs only.