### PR TITLE
feat: add HighLatitudeRule.recommended() helper

### DIFF
--- a/lib/src/HighLatitudeRule.dart
+++ b/lib/src/HighLatitudeRule.dart
@@ -1,2 +1,21 @@
+import 'package:adhan_dart/src/Coordinates.dart';
+
 /// Used to handle prayer time calculations in high latitude regions
-enum HighLatitudeRule { middleOfTheNight, seventhOfTheNight, twilightAngle }
+enum HighLatitudeRule {
+  middleOfTheNight,
+  seventhOfTheNight,
+  twilightAngle;
+
+  /// Returns the recommended high latitude rule for the given coordinates.
+  ///
+  /// For latitudes above 48°, [seventhOfTheNight] is recommended because
+  /// twilight-based calculations become unreliable at higher latitudes.
+  /// For latitudes at or below 48°, [middleOfTheNight] is sufficient.
+  static HighLatitudeRule recommended(Coordinates coordinates) {
+    if (coordinates.latitude > 48) {
+      return HighLatitudeRule.seventhOfTheNight;
+    } else {
+      return HighLatitudeRule.middleOfTheNight;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `HighLatitudeRule.recommended()` static method that returns the appropriate high latitude rule based on the observer's coordinates, matching the functionality available in adhan-js.

- Returns `seventhOfTheNight` for latitudes above 48° where twilight-based calculations become unreliable
- Returns `middleOfTheNight` for latitudes at or below 48°

This makes it easier for users to select the correct high latitude adjustment without needing to know the threshold themselves.

## Usage

```dart
var coordinates = Coordinates(59.9139, 10.7522); // Oslo
var rule = HighLatitudeRule.recommended(coordinates);
// returns HighLatitudeRule.seventhOfTheNight
```

## Changes

- Added `recommended()` static method to `HighLatitudeRule` enum
- Added import for `Coordinates` class

## Reference

Ported from the equivalent functionality in [adhan-js](https://github.com/batoulapps/adhan-js).