### PR TITLE
feat: add Shafaq parameter for MoonsightingCommittee

### DIFF
--- a/lib/adhan_dart.dart
+++ b/lib/adhan_dart.dart
@@ -8,3 +8,4 @@ export 'package:adhan_dart/src/Prayer.dart';
 export 'package:adhan_dart/src/PrayerTimes.dart';
 export 'package:adhan_dart/src/Qibla.dart';
 export 'package:adhan_dart/src/HighLatitudeRule.dart';
+export 'package:adhan_dart/src/Shafaq.dart';

--- a/lib/src/Astronomical.dart
+++ b/lib/src/Astronomical.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:adhan_dart/src/MathUtils.dart';
 import 'package:adhan_dart/src/DateUtils.dart';
+import 'package:adhan_dart/src/Shafaq.dart';
 
 class Astronomical {
   /* The geometric mean longitude of the sun in degrees. */
@@ -309,11 +310,27 @@ class Astronomical {
   }
 
   static DateTime seasonAdjustedEveningTwilight(
-      double latitude, int dayOfYear, int year, DateTime sunset) {
-    double a = 75 + ((25.60 / 55.0) * (latitude).abs());
-    double b = 75 + ((2.050 / 55.0) * (latitude).abs());
-    double c = 75 - ((9.210 / 55.0) * (latitude).abs());
-    double d = 75 + ((6.140 / 55.0) * (latitude).abs());
+      double latitude, int dayOfYear, int year, DateTime sunset,
+      {Shafaq shafaq = Shafaq.general}) {
+    double a, b, c, d;
+
+    if (shafaq == Shafaq.ahmer) {
+      a = 62 + ((17.4 / 55.0) * (latitude).abs());
+      b = 62 - ((7.16 / 55.0) * (latitude).abs());
+      c = 62 + ((5.12 / 55.0) * (latitude).abs());
+      d = 62 + ((19.44 / 55.0) * (latitude).abs());
+    } else if (shafaq == Shafaq.abyad) {
+      a = 75 + ((25.60 / 55.0) * (latitude).abs());
+      b = 75 + ((7.16 / 55.0) * (latitude).abs());
+      c = 75 + ((36.84 / 55.0) * (latitude).abs());
+      d = 75 + ((81.84 / 55.0) * (latitude).abs());
+    } else {
+      // Shafaq.general (default)
+      a = 75 + ((25.60 / 55.0) * (latitude).abs());
+      b = 75 + ((2.050 / 55.0) * (latitude).abs());
+      c = 75 - ((9.210 / 55.0) * (latitude).abs());
+      d = 75 + ((6.140 / 55.0) * (latitude).abs());
+    }
 
     double adjustment() {
       int dyy = Astronomical.daysSinceSolstice(dayOfYear, year, latitude);

--- a/lib/src/CalculationParameters.dart
+++ b/lib/src/CalculationParameters.dart
@@ -7,6 +7,7 @@ class CalculationParameters {
   int? ishaInterval;
   double? maghribAngle;
   Madhab? madhab;
+  Shafaq? shafaq;
 
   HighLatitudeRule? highLatitudeRule;
   late Map<Prayer, int> adjustments;
@@ -20,6 +21,7 @@ class CalculationParameters {
       double? maghribAngle,
       HighLatitudeRule? highLatitudeRule,
       Madhab? madhab,
+      Shafaq? shafaq,
       Map<Prayer, int>? adjustments,
       Map<Prayer, int>? methodAdjustments}) {
     this.method = method;
@@ -28,6 +30,7 @@ class CalculationParameters {
     this.ishaInterval = ishaInterval ?? 0;
     this.maghribAngle = maghribAngle;
     this.madhab = madhab ?? Madhab.shafi;
+    this.shafaq = shafaq ?? Shafaq.general;
     this.highLatitudeRule =
         highLatitudeRule ?? HighLatitudeRule.middleOfTheNight;
     this.adjustments = adjustments ??
@@ -57,6 +60,7 @@ class CalculationParameters {
     int? ishaInterval,
     double? maghribAngle,
     Madhab? madhab,
+    Shafaq? shafaq,
     HighLatitudeRule? highLatitudeRule,
     Map<Prayer, int>? adjustments,
     Map<Prayer, int>? methodAdjustments,
@@ -65,9 +69,10 @@ class CalculationParameters {
         method: method ?? this.method,
         fajrAngle: fajrAngle ?? this.fajrAngle,
         ishaAngle: ishaAngle ?? this.ishaAngle,
-
-        // maghribAngle: maghribAngle ?? this.maghribAngle,
+        ishaInterval: ishaInterval ?? this.ishaInterval,
+        maghribAngle: maghribAngle ?? this.maghribAngle,
         madhab: madhab ?? this.madhab,
+        shafaq: shafaq ?? this.shafaq,
         highLatitudeRule: highLatitudeRule ?? this.highLatitudeRule,
         adjustments: adjustments ?? this.adjustments,
         methodAdjustments: methodAdjustments ?? this.methodAdjustments,

--- a/lib/src/PrayerTimes.dart
+++ b/lib/src/PrayerTimes.dart
@@ -157,7 +157,8 @@ class PrayerTimes {
       DateTime safeIsha() {
         if (calculationParameters.method == CalculationMethod.moonsightingCommittee) {
           return Astronomical.seasonAdjustedEveningTwilight(
-              coordinates.latitude, dayOfYear(date), date.year, sunsetTime);
+              coordinates.latitude, dayOfYear(date), date.year, sunsetTime,
+              shafaq: calculationParameters.shafaq ?? Shafaq.general);
         } else {
           double portion = calculationParameters.nightPortions()[Prayer.isha]!;
           nightFraction = portion * night;
@@ -168,7 +169,8 @@ class PrayerTimes {
       DateTime safeIshaBefore() {
         if (calculationParameters.method == CalculationMethod.moonsightingCommittee) {
           return Astronomical.seasonAdjustedEveningTwilight(
-              coordinates.latitude, dayOfYear(date), date.year, sunsetTime);
+              coordinates.latitude, dayOfYear(date), date.year, sunsetTime,
+              shafaq: calculationParameters.shafaq ?? Shafaq.general);
         } else {
           var portion = calculationParameters.nightPortions()[Prayer.isha]!;
           nightFraction = portion * night;

--- a/lib/src/Shafaq.dart
+++ b/lib/src/Shafaq.dart
@@ -1,0 +1,15 @@
+/// Shafaq is the twilight glow observed after sunset, used by the
+/// MoonsightingCommittee method to determine Isha time.
+enum Shafaq {
+  /// General is a combination of Ahmer and Abyad. This is the default value
+  /// and is recommended for most locations.
+  general,
+
+  /// Ahmer means the twilight is the red glow in the sky.
+  /// Used by the Shafi, Maliki, and Hanbali madhabs.
+  ahmer,
+
+  /// Abyad means the twilight is the white glow in the sky.
+  /// Used by the Hanafi madhab.
+  abyad,
+}


### PR DESCRIPTION
## Summary

Adds a `Shafaq` enum to control how evening twilight is calculated for the MoonsightingCommittee method, matching the functionality available in adhan-js.

The MoonsightingCommittee method uses season-adjusted twilight for Isha calculations. Different schools have different definitions of twilight:

- **General** (default): A combined approach — this is the existing behavior, so this change is fully backward-compatible
- **Ahmer** (red glow): Used by Shafi, Maliki, and Hanbali madhabs
- **Abyad** (white glow): Used by the Hanafi madhab

## Usage

```dart
var params = CalculationMethod.MoonsightingCommittee();
params.shafaq = Shafaq.ahmer; // Use red twilight for Isha
```

## Changes

- New `Shafaq` enum in `lib/src/Shafaq.dart` with three values: `general`, `ahmer`, `abyad`
- Updated `seasonAdjustedEveningTwilight()` in `Astronomical.dart` to accept a `shafaq` parameter with three distinct coefficient sets
- Added `shafaq` property to `CalculationParameters` (defaults to `Shafaq.general`)
- Updated `copyWith()` to include `shafaq`
- `PrayerTimes` now passes `shafaq` when computing safe Isha for MoonsightingCommittee
- Exported `Shafaq` from `adhan_dart.dart`

## Reference

Ported from [adhan-js Shafaq implementation](https://github.com/batoulapps/adhan-js).