### PR TITLE
feat: add Rounding configuration for prayer times

### DIFF
--- a/lib/adhan_dart.dart
+++ b/lib/adhan_dart.dart
@@ -8,3 +8,4 @@ export 'package:adhan_dart/src/Prayer.dart';
 export 'package:adhan_dart/src/PrayerTimes.dart';
 export 'package:adhan_dart/src/Qibla.dart';
 export 'package:adhan_dart/src/HighLatitudeRule.dart';
+export 'package:adhan_dart/src/Rounding.dart';

--- a/lib/src/CalculationMethod.dart
+++ b/lib/src/CalculationMethod.dart
@@ -167,6 +167,7 @@ class CalculationMethodParameters {
     CalculationParameters params = CalculationParameters(
         method: CalculationMethod.singapore, fajrAngle: 20, ishaAngle: 18);
     params.methodAdjustments = {Prayer.dhuhr: 1};
+    params.rounding = Rounding.up;
     return params;
   }
 

--- a/lib/src/CalculationParameters.dart
+++ b/lib/src/CalculationParameters.dart
@@ -7,6 +7,7 @@ class CalculationParameters {
   int? ishaInterval;
   double? maghribAngle;
   Madhab? madhab;
+  late Rounding rounding;
 
   HighLatitudeRule? highLatitudeRule;
   late Map<Prayer, int> adjustments;
@@ -20,6 +21,7 @@ class CalculationParameters {
       double? maghribAngle,
       HighLatitudeRule? highLatitudeRule,
       Madhab? madhab,
+      Rounding? rounding,
       Map<Prayer, int>? adjustments,
       Map<Prayer, int>? methodAdjustments}) {
     this.method = method;
@@ -28,6 +30,7 @@ class CalculationParameters {
     this.ishaInterval = ishaInterval ?? 0;
     this.maghribAngle = maghribAngle;
     this.madhab = madhab ?? Madhab.shafi;
+    this.rounding = rounding ?? Rounding.nearest;
     this.highLatitudeRule =
         highLatitudeRule ?? HighLatitudeRule.middleOfTheNight;
     this.adjustments = adjustments ??
@@ -57,6 +60,7 @@ class CalculationParameters {
     int? ishaInterval,
     double? maghribAngle,
     Madhab? madhab,
+    Rounding? rounding,
     HighLatitudeRule? highLatitudeRule,
     Map<Prayer, int>? adjustments,
     Map<Prayer, int>? methodAdjustments,
@@ -65,9 +69,10 @@ class CalculationParameters {
         method: method ?? this.method,
         fajrAngle: fajrAngle ?? this.fajrAngle,
         ishaAngle: ishaAngle ?? this.ishaAngle,
-
-        // maghribAngle: maghribAngle ?? this.maghribAngle,
+        ishaInterval: ishaInterval ?? this.ishaInterval,
+        maghribAngle: maghribAngle ?? this.maghribAngle,
         madhab: madhab ?? this.madhab,
+        rounding: rounding ?? this.rounding,
         highLatitudeRule: highLatitudeRule ?? this.highLatitudeRule,
         adjustments: adjustments ?? this.adjustments,
         methodAdjustments: methodAdjustments ?? this.methodAdjustments,

--- a/lib/src/DateUtils.dart
+++ b/lib/src/DateUtils.dart
@@ -1,4 +1,4 @@
-// import 'package:adhan_dart/src/Astronomical.dart';
+import 'package:adhan_dart/src/Rounding.dart';
 
 DateTime dateByAddingDays(DateTime date, int days) {
   return date.add(Duration(days: days));
@@ -20,10 +20,21 @@ int dayOfYear(DateTime date) {
   return returnedDayOfYear;
 }
 
-DateTime roundedMinute(DateTime date, {bool precision = true}) {
+DateTime roundedMinute(DateTime date,
+    {bool precision = true, Rounding rounding = Rounding.nearest}) {
+  if (precision && rounding == Rounding.nearest) return date;
+
   int seconds = date.toUtc().second % 60;
-  int offset = seconds >= 30 ? 60 - seconds : -1 * seconds;
-  if (precision) return date;
+  int offset;
+
+  if (rounding == Rounding.none) {
+    return date;
+  } else if (rounding == Rounding.up) {
+    offset = seconds > 0 ? 60 - seconds : 0;
+  } else {
+    // Rounding.nearest
+    offset = seconds >= 30 ? 60 - seconds : -1 * seconds;
+  }
 
   return dateByAddingSeconds(date, offset);
 }

--- a/lib/src/PrayerTimes.dart
+++ b/lib/src/PrayerTimes.dart
@@ -210,19 +210,26 @@ class PrayerTimes {
     int ishaAdjustment = (calculationParameters.adjustments[Prayer.isha] ?? 0) +
         (calculationParameters.methodAdjustments[Prayer.isha] ?? 0);
 
-    fajr = roundedMinute(dateByAddingMinutes(fajrTime, fajrAdjustment), precision: precision);
-    sunrise =
-        roundedMinute(dateByAddingMinutes(sunriseTime, sunriseAdjustment), precision: precision);
-    dhuhr = roundedMinute(dateByAddingMinutes(dhuhrTime, dhuhrAdjustment), precision: precision);
-    asr = roundedMinute(dateByAddingMinutes(asrTime, asrAdjustment), precision: precision);
-    maghrib =
-        roundedMinute(dateByAddingMinutes(maghribTime, maghribAdjustment), precision: precision);
-    isha = roundedMinute(dateByAddingMinutes(ishaTime, ishaAdjustment), precision: precision);
+    Rounding rounding =
+        precision ? Rounding.none : calculationParameters.rounding;
 
-    fajrAfter =
-        roundedMinute(dateByAddingMinutes(fajrafterTime, fajrAdjustment), precision: precision);
-    ishaBefore =
-        roundedMinute(dateByAddingMinutes(ishabeforeTime, ishaAdjustment), precision: precision);
+    fajr = roundedMinute(dateByAddingMinutes(fajrTime, fajrAdjustment),
+        precision: false, rounding: rounding);
+    sunrise = roundedMinute(dateByAddingMinutes(sunriseTime, sunriseAdjustment),
+        precision: false, rounding: rounding);
+    dhuhr = roundedMinute(dateByAddingMinutes(dhuhrTime, dhuhrAdjustment),
+        precision: false, rounding: rounding);
+    asr = roundedMinute(dateByAddingMinutes(asrTime, asrAdjustment),
+        precision: false, rounding: rounding);
+    maghrib = roundedMinute(dateByAddingMinutes(maghribTime, maghribAdjustment),
+        precision: false, rounding: rounding);
+    isha = roundedMinute(dateByAddingMinutes(ishaTime, ishaAdjustment),
+        precision: false, rounding: rounding);
+
+    fajrAfter = roundedMinute(dateByAddingMinutes(fajrafterTime, fajrAdjustment),
+        precision: false, rounding: rounding);
+    ishaBefore = roundedMinute(dateByAddingMinutes(ishabeforeTime, ishaAdjustment),
+        precision: false, rounding: rounding);
   }
 
   /// Returns the current prayer for the given date.

--- a/lib/src/Rounding.dart
+++ b/lib/src/Rounding.dart
@@ -1,0 +1,11 @@
+/// Controls how prayer times are rounded to the nearest minute.
+enum Rounding {
+  /// Round to the nearest minute. This is the default.
+  nearest,
+
+  /// Always round up to the next minute.
+  up,
+
+  /// No rounding. Times are returned with second precision.
+  none,
+}


### PR DESCRIPTION
## Summary

Adds a `Rounding` enum to control how prayer times are rounded to the nearest minute, matching the functionality available in adhan-js.

Currently, rounding is controlled by the `precision` boolean parameter on `PrayerTimes`. This PR adds a more flexible `Rounding` configuration on `CalculationParameters` that supports three modes:

- **nearest** (default): Rounds to the nearest minute — same as current behavior
- **up**: Always rounds up to the next minute — used by Singapore method
- **none**: No rounding, returns times with second precision — equivalent to `precision: true`

## Usage

```dart
var params = CalculationMethod.Singapore();
// Singapore already defaults to Rounding.up

// Or set manually on any method:
var params = CalculationMethod.MuslimWorldLeague();
params.rounding = Rounding.up;
```

## Backward Compatibility

The existing `precision` parameter on `PrayerTimes` is preserved:
- `precision: true` overrides to `Rounding.none` (same behavior as before)
- `precision: false` (default) uses `calculationParameters.rounding`

## Changes

- New `Rounding` enum in `lib/src/Rounding.dart`
- Updated `roundedMinute()` in `DateUtils.dart` to support all three rounding modes
- Added `rounding` property to `CalculationParameters` (defaults to `Rounding.nearest`)
- Updated `copyWith()` to include `rounding` (also fixed missing `ishaInterval` and `maghribAngle`)
- Singapore method now defaults to `Rounding.up`
- Exported `Rounding` from `adhan_dart.dart`

## Reference

Ported from [adhan-js Rounding implementation](https://github.com/batoulapps/adhan-js).