### PR TITLE
feat: expose sunset property on PrayerTimes

### DIFF
--- a/lib/src/PrayerTimes.dart
+++ b/lib/src/PrayerTimes.dart
@@ -25,6 +25,9 @@ class PrayerTimes {
   /// Asr prayer time
   late DateTime asr;
 
+  /// Sunset time (astronomical sunset, before maghrib adjustments)
+  late DateTime sunset;
+
   /// Maghrib prayer time
   late DateTime maghrib;
 
@@ -215,6 +218,7 @@ class PrayerTimes {
         roundedMinute(dateByAddingMinutes(sunriseTime, sunriseAdjustment), precision: precision);
     dhuhr = roundedMinute(dateByAddingMinutes(dhuhrTime, dhuhrAdjustment), precision: precision);
     asr = roundedMinute(dateByAddingMinutes(asrTime, asrAdjustment), precision: precision);
+    sunset = roundedMinute(sunsetTime, precision: precision);
     maghrib =
         roundedMinute(dateByAddingMinutes(maghribTime, maghribAdjustment), precision: precision);
     isha = roundedMinute(dateByAddingMinutes(ishaTime, ishaAdjustment), precision: precision);


### PR DESCRIPTION
## Summary

Exposes the astronomical sunset time as a public `sunset` property on `PrayerTimes`, matching adhan-js.

Currently, sunset is calculated internally as `sunsetTime` but not accessible to users. This matters because `maghrib` can differ from the raw sunset time when:
- A `maghribAngle` is configured (e.g., Tehran method uses 4.5°)
- Method adjustments shift Maghrib (e.g., Morocco adds +5 minutes)

Having both `sunset` and `maghrib` available allows apps to distinguish between the astronomical event and the adjusted prayer time.

## Usage

```dart
var pt = PrayerTimes(
  coordinates: coordinates,
  date: date,
  calculationParameters: params,
);

print(pt.sunset);  // Astronomical sunset
print(pt.maghrib); // May differ due to method adjustments
```

## Changes

- Added `late DateTime sunset` property to `PrayerTimes`
- Assigned `sunset` from the computed `sunsetTime` with rounding applied