### PR TITLE
chore: replace deprecated flutter_lints with lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,9 +5,8 @@
 # IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
 # invoked from the command line by running `flutter analyze`.
 
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
-include: package:flutter_lints/flutter.yaml
+# The following line activates a set of recommended lints for Dart packages.
+include: package:lints/recommended.yaml
 
 linter:
     # The lint rules applied to this project can be customized in the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
 
 dev_dependencies:
     timezone: ^0.10.1
-    flutter_lints: ^6.0.0
+    lints: ^2.1.0


### PR DESCRIPTION
## Summary

Replaces the deprecated `flutter_lints` package with the `lints` package.

`flutter_lints` has been deprecated and is no longer maintained. Since adhan_dart is a pure Dart package (no Flutter dependency), the correct replacement is the `lints` package which provides standard recommended lint rules for Dart packages.

## Changes

- Replaced `flutter_lints: ^6.0.0` with `lints: ^2.1.0` in dev_dependencies
- Updated `analysis_options.yaml` include from `package:flutter_lints/flutter.yaml` to `package:lints/recommended.yaml`
- `lints: ^2.1.0` is compatible with the existing SDK constraint `>=2.19.0 <4.0.0`
- `dart analyze` passes with zero issues