### PR TITLE
fix: replace dynamic with Coordinates type in correctedHourAngle

### DIFF
--- a/lib/src/Astronomical.dart
+++ b/lib/src/Astronomical.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:adhan_dart/src/Coordinates.dart';
 import 'package:adhan_dart/src/MathUtils.dart';
 import 'package:adhan_dart/src/DateUtils.dart';
 
@@ -176,7 +177,7 @@ class Astronomical {
   static double correctedHourAngle(
       double? approximateTransit,
       double angle,
-      dynamic coordinates,
+      Coordinates coordinates,
       bool afterTransit,
       double siderealTime,
       double rightAscension,


### PR DESCRIPTION
## Summary

The `coordinates` parameter in `Astronomical.correctedHourAngle()` was typed as `dynamic` instead of `Coordinates`. This bypasses Dart's type system — any object could be passed without a compile-time error, and property access on `coordinates.latitude`/`coordinates.longitude` would only fail at runtime.

## Changes

- Changed `dynamic coordinates` to `Coordinates coordinates` in `correctedHourAngle()`
- Added import for `Coordinates` class in `Astronomical.dart`