### PR TITLE
style: apply dart format to library source files

### DIFF
--- a/lib/src/Astronomical.dart
+++ b/lib/src/Astronomical.dart
@@ -52,7 +52,8 @@ class Astronomical {
     double T = julianCentury;
     /* Equation from Astronomical Algorithms page 164 */
     double mrad = degreesToRadians(meanAnomaly);
-    double term1 = (1.914602 - (0.004817 * T) - (0.000014 * pow(T, 2))) * sin(mrad);
+    double term1 =
+        (1.914602 - (0.004817 * T) - (0.000014 * pow(T, 2))) * sin(mrad);
     double term2 = (0.019993 - (0.000101 * T)) * sin(2 * mrad);
     double term3 = 0.000289 * sin(3 * mrad);
     return term1 + term2 + term3;
@@ -60,14 +61,17 @@ class Astronomical {
 
   /* The apparent longitude of the Sun, referred to the
         true equinox of the date. */
-  static double apparentSolarLongitude(double julianCentury, double meanLongitude) {
+  static double apparentSolarLongitude(
+      double julianCentury, double meanLongitude) {
     double T = julianCentury;
     double l0 = meanLongitude;
     /* Equation from Astronomical Algorithms page 164 */
-    double longitude =
-        l0 + Astronomical.solarEquationOfTheCenter(T, Astronomical.meanSolarAnomaly(T));
+    double longitude = l0 +
+        Astronomical.solarEquationOfTheCenter(
+            T, Astronomical.meanSolarAnomaly(T));
     double omega = 125.04 - (1934.136 * T);
-    double lambda = longitude - 0.00569 - (0.00478 * sin(degreesToRadians(omega)));
+    double lambda =
+        longitude - 0.00569 - (0.00478 * sin(degreesToRadians(omega)));
     return unwindAngle(lambda);
   }
 
@@ -108,8 +112,8 @@ class Astronomical {
     return unwindAngle(theta);
   }
 
-  static double nutationInLongitude(
-      double julianCentury, double solarLongitude, double lunarLongitude, double ascendingNode) {
+  static double nutationInLongitude(double julianCentury, double solarLongitude,
+      double lunarLongitude, double ascendingNode) {
     double l0 = solarLongitude;
     double lp = lunarLongitude;
     double omega = ascendingNode;
@@ -121,8 +125,8 @@ class Astronomical {
     return term1 - term2 - term3 + term4;
   }
 
-  static double nutationInObliquity(
-      double julianCentury, double solarLongitude, double lunarLongitude, double ascendingNode) {
+  static double nutationInObliquity(double julianCentury, double solarLongitude,
+      double lunarLongitude, double ascendingNode) {
     double l0 = solarLongitude;
     double lp = lunarLongitude;
     double omega = ascendingNode;
@@ -141,12 +145,14 @@ class Astronomical {
     double H = localHourAngle;
     /* Equation from Astronomical Algorithms page 93 */
     double term1 = sin(degreesToRadians(phi)) * sin(degreesToRadians(delta));
-    double term2 =
-        cos(degreesToRadians(phi)) * cos(degreesToRadians(delta)) * cos(degreesToRadians(H));
+    double term2 = cos(degreesToRadians(phi)) *
+        cos(degreesToRadians(delta)) *
+        cos(degreesToRadians(H));
     return radiansToDegrees(asin(term1 + term2));
   }
 
-  static double approximateTransit(double longitude, double siderealTime, double rightAscension) {
+  static double approximateTransit(
+      double longitude, double siderealTime, double rightAscension) {
     double L = longitude;
     double theta0 = siderealTime;
     double a2 = rightAscension;
@@ -156,8 +162,13 @@ class Astronomical {
   }
 
   /* The time at which the sun is at its highest point in the sky (in universal time) */
-  static double correctedTransit(double approximateTransit, double longitude, double siderealTime,
-      double rightAscension, double? previousRightAscension, double nextRightAscension) {
+  static double correctedTransit(
+      double approximateTransit,
+      double longitude,
+      double siderealTime,
+      double rightAscension,
+      double? previousRightAscension,
+      double nextRightAscension) {
     double m0 = approximateTransit;
     double L = longitude;
     double theta0 = siderealTime;
@@ -198,18 +209,22 @@ class Astronomical {
     /* Equation from page Astronomical Algorithms 102 */
     double lw = coordinates.longitude * -1;
     double term1 = sin(degreesToRadians(h02)) -
-        (sin(degreesToRadians(coordinates.latitude)) * sin(degreesToRadians(d2)));
-    double term2 = cos(degreesToRadians(coordinates.latitude)) * cos(degreesToRadians(d2));
+        (sin(degreesToRadians(coordinates.latitude)) *
+            sin(degreesToRadians(d2)));
+    double term2 =
+        cos(degreesToRadians(coordinates.latitude)) * cos(degreesToRadians(d2));
 
     // TODO: acos with term1/term2 > 1 or < -1
-    double h021 = (term1 / term2).abs() > 1 ? 1.0 : radiansToDegrees(acos(term1 / term2));
+    double h021 =
+        (term1 / term2).abs() > 1 ? 1.0 : radiansToDegrees(acos(term1 / term2));
 
     double m = afterTransit ? m0! + (h021 / 360) : m0! - (h021 / 360);
     double theta = unwindAngle((theta0 + (360.985647 * m)));
     double a = unwindAngle(Astronomical.interpolateAngles(a2, a1, a3, m)!);
     double delta = Astronomical.interpolate(d2, d1, d3, m)!;
     double H = (theta - lw - a);
-    double h = Astronomical.altitudeOfCelestialBody(coordinates.latitude, delta, H);
+    double h =
+        Astronomical.altitudeOfCelestialBody(coordinates.latitude, delta, H);
     double term3 = h - h02;
     double term4 = 360 *
         cos(degreesToRadians(delta)) *

--- a/lib/src/PrayerTimes.dart
+++ b/lib/src/PrayerTimes.dart
@@ -11,7 +11,8 @@ import 'package:adhan_dart/src/TimeComponents.dart';
 class PrayerTimes {
   DateTime date = DateTime.now();
   Coordinates coordinates = const Coordinates(0, 0);
-  CalculationParameters calculationParameters = CalculationMethodParameters.muslimWorldLeague();
+  CalculationParameters calculationParameters =
+      CalculationMethodParameters.muslimWorldLeague();
 
   /// Fajr prayer time
   late DateTime fajr;
@@ -70,18 +71,21 @@ class PrayerTimes {
 
     double? nightFraction;
 
-    DateTime dhuhrTime = TimeComponents(solarTime.transit).utcDate(date.year, date.month, date.day);
-    DateTime sunriseTime =
-        TimeComponents(solarTime.sunrise).utcDate(date.year, date.month, date.day);
-    DateTime sunsetTime = TimeComponents(solarTime.sunset).utcDate(date.year, date.month, date.day);
+    DateTime dhuhrTime = TimeComponents(solarTime.transit)
+        .utcDate(date.year, date.month, date.day);
+    DateTime sunriseTime = TimeComponents(solarTime.sunrise)
+        .utcDate(date.year, date.month, date.day);
+    DateTime sunsetTime = TimeComponents(solarTime.sunset)
+        .utcDate(date.year, date.month, date.day);
 
     DateTime sunriseafterTime = TimeComponents(solarTimeAfter.sunrise)
         .utcDate(dateAfter.year, dateAfter.month, dateAfter.day);
     DateTime sunsetbeforeTime = TimeComponents(solarTimeBefore.sunset)
         .utcDate(dateBefore.year, dateBefore.month, dateBefore.day);
 
-    asrTime = TimeComponents(solarTime
-            .afternoon(shadowLength(calculationParameters.madhab ?? Madhab.shafi).toDouble()))
+    asrTime = TimeComponents(solarTime.afternoon(
+            shadowLength(calculationParameters.madhab ?? Madhab.shafi)
+                .toDouble()))
         .utcDate(date.year, date.month, date.day);
 
     DateTime tomorrow = dateByAddingDays(date, 1);
@@ -91,23 +95,27 @@ class PrayerTimes {
     // var night = (tomorrowSunrise - sunsetTime) / 1000;
     int night = (tomorrowSunrise.difference(sunsetTime)).inSeconds;
 
-    fajrTime = TimeComponents(solarTime.hourAngle(-1 * calculationParameters.fajrAngle, false))
+    fajrTime = TimeComponents(
+            solarTime.hourAngle(-1 * calculationParameters.fajrAngle, false))
         .utcDate(date.year, date.month, date.day);
 
-    fajrafterTime =
-        TimeComponents(solarTimeAfter.hourAngle(-1 * calculationParameters.fajrAngle, false))
-            .utcDate(dateAfter.year, dateAfter.month, dateAfter.day);
+    fajrafterTime = TimeComponents(solarTimeAfter.hourAngle(
+            -1 * calculationParameters.fajrAngle, false))
+        .utcDate(dateAfter.year, dateAfter.month, dateAfter.day);
 
     // special case for moonsighting committee above latitude 55
-    if (calculationParameters.method == CalculationMethod.moonsightingCommittee &&
+    if (calculationParameters.method ==
+            CalculationMethod.moonsightingCommittee &&
         coordinates.latitude >= 55) {
       nightFraction = night / 7;
       fajrTime = dateByAddingSeconds(sunriseTime, -nightFraction.round());
-      fajrafterTime = dateByAddingSeconds(sunriseafterTime, -nightFraction.round());
+      fajrafterTime =
+          dateByAddingSeconds(sunriseafterTime, -nightFraction.round());
     }
 
     DateTime safeFajr() {
-      if (calculationParameters.method == CalculationMethod.moonsightingCommittee) {
+      if (calculationParameters.method ==
+          CalculationMethod.moonsightingCommittee) {
         return Astronomical.seasonAdjustedMorningTwilight(
             coordinates.latitude, dayOfYear(date), date.year, sunriseTime);
       } else {
@@ -133,29 +141,37 @@ class PrayerTimes {
       fajrTime = safeFajr();
     }
 
-    if (fajrafterTime.millisecondsSinceEpoch.isNaN || safeFajr().isAfter(fajrafterTime)) {
+    if (fajrafterTime.millisecondsSinceEpoch.isNaN ||
+        safeFajr().isAfter(fajrafterTime)) {
       fajrafterTime = safeFajr();
     }
 
-    if (calculationParameters.ishaInterval != null && calculationParameters.ishaInterval! > 0) {
-      ishaTime = dateByAddingMinutes(sunsetTime, calculationParameters.ishaInterval!);
-      ishabeforeTime = dateByAddingMinutes(sunsetbeforeTime, calculationParameters.ishaInterval!);
+    if (calculationParameters.ishaInterval != null &&
+        calculationParameters.ishaInterval! > 0) {
+      ishaTime =
+          dateByAddingMinutes(sunsetTime, calculationParameters.ishaInterval!);
+      ishabeforeTime = dateByAddingMinutes(
+          sunsetbeforeTime, calculationParameters.ishaInterval!);
     } else {
-      ishaTime = TimeComponents(solarTime.hourAngle(-1 * calculationParameters.ishaAngle, true))
+      ishaTime = TimeComponents(
+              solarTime.hourAngle(-1 * calculationParameters.ishaAngle, true))
           .utcDate(date.year, date.month, date.day);
-      ishabeforeTime =
-          TimeComponents(solarTimeBefore.hourAngle(-1 * calculationParameters.ishaAngle, true))
-              .utcDate(dateBefore.year, dateBefore.month, dateBefore.day);
+      ishabeforeTime = TimeComponents(solarTimeBefore.hourAngle(
+              -1 * calculationParameters.ishaAngle, true))
+          .utcDate(dateBefore.year, dateBefore.month, dateBefore.day);
       // special case for moonsighting committee above latitude 55
-      if (calculationParameters.method == CalculationMethod.moonsightingCommittee &&
+      if (calculationParameters.method ==
+              CalculationMethod.moonsightingCommittee &&
           coordinates.latitude >= 55) {
         nightFraction = night / 7;
         ishaTime = dateByAddingSeconds(sunsetTime, nightFraction!.round());
-        ishabeforeTime = dateByAddingSeconds(sunsetbeforeTime, nightFraction!.round());
+        ishabeforeTime =
+            dateByAddingSeconds(sunsetbeforeTime, nightFraction!.round());
       }
 
       DateTime safeIsha() {
-        if (calculationParameters.method == CalculationMethod.moonsightingCommittee) {
+        if (calculationParameters.method ==
+            CalculationMethod.moonsightingCommittee) {
           return Astronomical.seasonAdjustedEveningTwilight(
               coordinates.latitude, dayOfYear(date), date.year, sunsetTime);
         } else {
@@ -166,7 +182,8 @@ class PrayerTimes {
       }
 
       DateTime safeIshaBefore() {
-        if (calculationParameters.method == CalculationMethod.moonsightingCommittee) {
+        if (calculationParameters.method ==
+            CalculationMethod.moonsightingCommittee) {
           return Astronomical.seasonAdjustedEveningTwilight(
               coordinates.latitude, dayOfYear(date), date.year, sunsetTime);
         } else {
@@ -176,7 +193,8 @@ class PrayerTimes {
         }
       }
 
-      if (ishaTime.millisecondsSinceEpoch.isNaN || safeIsha().isBefore(ishaTime)) {
+      if (ishaTime.millisecondsSinceEpoch.isNaN ||
+          safeIsha().isBefore(ishaTime)) {
         ishaTime = safeIsha();
       }
 
@@ -188,10 +206,11 @@ class PrayerTimes {
 
     maghribTime = sunsetTime;
     if (calculationParameters.maghribAngle != null) {
-      DateTime angleBasedMaghrib =
-          TimeComponents(solarTime.hourAngle(-1 * calculationParameters.maghribAngle!, true))
-              .utcDate(date.year, date.month, date.day);
-      if (sunsetTime.isBefore(angleBasedMaghrib) && ishaTime.isAfter(angleBasedMaghrib)) {
+      DateTime angleBasedMaghrib = TimeComponents(solarTime.hourAngle(
+              -1 * calculationParameters.maghribAngle!, true))
+          .utcDate(date.year, date.month, date.day);
+      if (sunsetTime.isBefore(angleBasedMaghrib) &&
+          ishaTime.isAfter(angleBasedMaghrib)) {
         maghribTime = angleBasedMaghrib;
       }
     }
@@ -199,30 +218,39 @@ class PrayerTimes {
     // double fajrAdjustment = (calculationParameters.adjustments["fajr"] && 0) + (calculationParameters.methodAdjustments["fajr"] && 0);
     int fajrAdjustment = (calculationParameters.adjustments[Prayer.fajr] ?? 0) +
         (calculationParameters.methodAdjustments[Prayer.fajr] ?? 0);
-    int sunriseAdjustment = (calculationParameters.adjustments[Prayer.sunrise] ?? 0) +
-        (calculationParameters.methodAdjustments[Prayer.sunrise] ?? 0);
-    int dhuhrAdjustment = (calculationParameters.adjustments[Prayer.dhuhr] ?? 0) +
-        (calculationParameters.methodAdjustments[Prayer.dhuhr] ?? 0);
+    int sunriseAdjustment =
+        (calculationParameters.adjustments[Prayer.sunrise] ?? 0) +
+            (calculationParameters.methodAdjustments[Prayer.sunrise] ?? 0);
+    int dhuhrAdjustment =
+        (calculationParameters.adjustments[Prayer.dhuhr] ?? 0) +
+            (calculationParameters.methodAdjustments[Prayer.dhuhr] ?? 0);
     int asrAdjustment = (calculationParameters.adjustments[Prayer.asr] ?? 0) +
         (calculationParameters.methodAdjustments[Prayer.asr] ?? 0);
-    int maghribAdjustment = (calculationParameters.adjustments[Prayer.maghrib] ?? 0) +
-        (calculationParameters.methodAdjustments[Prayer.maghrib] ?? 0);
+    int maghribAdjustment =
+        (calculationParameters.adjustments[Prayer.maghrib] ?? 0) +
+            (calculationParameters.methodAdjustments[Prayer.maghrib] ?? 0);
     int ishaAdjustment = (calculationParameters.adjustments[Prayer.isha] ?? 0) +
         (calculationParameters.methodAdjustments[Prayer.isha] ?? 0);
 
-    fajr = roundedMinute(dateByAddingMinutes(fajrTime, fajrAdjustment), precision: precision);
-    sunrise =
-        roundedMinute(dateByAddingMinutes(sunriseTime, sunriseAdjustment), precision: precision);
-    dhuhr = roundedMinute(dateByAddingMinutes(dhuhrTime, dhuhrAdjustment), precision: precision);
-    asr = roundedMinute(dateByAddingMinutes(asrTime, asrAdjustment), precision: precision);
-    maghrib =
-        roundedMinute(dateByAddingMinutes(maghribTime, maghribAdjustment), precision: precision);
-    isha = roundedMinute(dateByAddingMinutes(ishaTime, ishaAdjustment), precision: precision);
+    fajr = roundedMinute(dateByAddingMinutes(fajrTime, fajrAdjustment),
+        precision: precision);
+    sunrise = roundedMinute(dateByAddingMinutes(sunriseTime, sunriseAdjustment),
+        precision: precision);
+    dhuhr = roundedMinute(dateByAddingMinutes(dhuhrTime, dhuhrAdjustment),
+        precision: precision);
+    asr = roundedMinute(dateByAddingMinutes(asrTime, asrAdjustment),
+        precision: precision);
+    maghrib = roundedMinute(dateByAddingMinutes(maghribTime, maghribAdjustment),
+        precision: precision);
+    isha = roundedMinute(dateByAddingMinutes(ishaTime, ishaAdjustment),
+        precision: precision);
 
-    fajrAfter =
-        roundedMinute(dateByAddingMinutes(fajrafterTime, fajrAdjustment), precision: precision);
-    ishaBefore =
-        roundedMinute(dateByAddingMinutes(ishabeforeTime, ishaAdjustment), precision: precision);
+    fajrAfter = roundedMinute(
+        dateByAddingMinutes(fajrafterTime, fajrAdjustment),
+        precision: precision);
+    ishaBefore = roundedMinute(
+        dateByAddingMinutes(ishabeforeTime, ishaAdjustment),
+        precision: precision);
   }
 
   /// Returns the current prayer for the given date.

--- a/lib/src/SolarCoordinates.dart
+++ b/lib/src/SolarCoordinates.dart
@@ -13,13 +13,14 @@ class SolarCoordinates {
     double l0 = Astronomical.meanSolarLongitude(T);
     double lp = Astronomical.meanLunarLongitude(T);
     double omega = Astronomical.ascendingLunarNodeLongitude(T);
-    double lambda = degreesToRadians(Astronomical.apparentSolarLongitude(T, l0));
+    double lambda =
+        degreesToRadians(Astronomical.apparentSolarLongitude(T, l0));
     double theta0 = Astronomical.meanSiderealTime(T);
     double dPsi = Astronomical.nutationInLongitude(T, l0, lp, omega);
     double dEpsilon = Astronomical.nutationInObliquity(T, l0, lp, omega);
     double epsilon0 = Astronomical.meanObliquityOfTheEcliptic(T);
-    double epsilonApparent =
-        degreesToRadians(Astronomical.apparentObliquityOfTheEcliptic(T, epsilon0));
+    double epsilonApparent = degreesToRadians(
+        Astronomical.apparentObliquityOfTheEcliptic(T, epsilon0));
 
     /* declination: The declination of the sun, the angle between
             the rays of the Sun and the plane of the Earth's
@@ -31,13 +32,13 @@ class SolarCoordinates {
             celestial equator from the vernal equinox to the hour circle,
             in degrees.
             Equation from Astronomical Algorithms page 165 */
-    rightAscension =
-        unwindAngle(radiansToDegrees(atan2(cos(epsilonApparent) * sin(lambda), cos(lambda))));
+    rightAscension = unwindAngle(radiansToDegrees(
+        atan2(cos(epsilonApparent) * sin(lambda), cos(lambda))));
 
     /* apparentSiderealTime: Apparent sidereal time, the hour angle of the vernal
             equinox, in degrees.
             Equation from Astronomical Algorithms page 88 */
-    apparentSiderealTime =
-        theta0 + (((dPsi * 3600) * cos(degreesToRadians(epsilon0 + dEpsilon))) / 3600);
+    apparentSiderealTime = theta0 +
+        (((dPsi * 3600) * cos(degreesToRadians(epsilon0 + dEpsilon))) / 3600);
   }
 }

--- a/lib/src/SolarTime.dart
+++ b/lib/src/SolarTime.dart
@@ -17,7 +17,8 @@ class SolarTime {
   late double sunset;
 
   SolarTime(DateTime date, Coordinates coordinates) {
-    double julianDay = Astronomical.julianDay(date.year, date.month, date.day, 0);
+    double julianDay =
+        Astronomical.julianDay(date.year, date.month, date.day, 0);
 
     observer = coordinates;
     solar = SolarCoordinates(julianDay);
@@ -25,14 +26,19 @@ class SolarTime {
     prevSolar = SolarCoordinates(julianDay - 1);
     nextSolar = SolarCoordinates(julianDay + 1);
 
-    double m0 = Astronomical.approximateTransit(
-        coordinates.longitude, solar.apparentSiderealTime, solar.rightAscension!);
+    double m0 = Astronomical.approximateTransit(coordinates.longitude,
+        solar.apparentSiderealTime, solar.rightAscension!);
     const solarAltitude = -50.0 / 60.0;
 
     approxTransit = m0;
 
-    transit = Astronomical.correctedTransit(m0, coordinates.longitude, solar.apparentSiderealTime,
-        solar.rightAscension!, prevSolar.rightAscension, nextSolar.rightAscension!);
+    transit = Astronomical.correctedTransit(
+        m0,
+        coordinates.longitude,
+        solar.apparentSiderealTime,
+        solar.rightAscension!,
+        prevSolar.rightAscension,
+        nextSolar.rightAscension!);
 
     sunrise = Astronomical.correctedHourAngle(
         m0,


### PR DESCRIPTION
## Summary

Runs `dart format` on the 4 library source files that had formatting inconsistencies:

- `Astronomical.dart`
- `PrayerTimes.dart`
- `SolarCoordinates.dart`
- `SolarTime.dart`

No logic changes — purely whitespace and line-length adjustments to comply with the `dart format` standard. This ensures the CI format check (PR #26) will pass on the existing codebase.