### PR TITLE
chore: improve pubspec.yaml metadata for pub.dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,13 @@ version: 1.2.0
 description: >-
     Library to calculate prayer times for muslims.
     Based on precise astronomical formula.
-homepage: https://github.com/prayer-timetable/adhan_dart/
-documentation: https://github.com/prayer-timetable/adhan_dart/
+repository: https://github.com/prayer-timetable/adhan_dart
+issue_tracker: https://github.com/prayer-timetable/adhan_dart/issues
+topics:
+    - prayer-times
+    - islamic
+    - adhan
+    - salah
 environment:
     sdk: '>=2.19.0  <4.0.0'
 dependencies:


### PR DESCRIPTION
## Summary

Improves the pubspec.yaml metadata following pub.dev recommendations:

- **`repository`** and **`issue_tracker`** fields replace `homepage` and `documentation` — pub.dev prefers these fields and uses them to show links to the repo and issue tracker directly on the package page
- **`topics`** added: `prayer-times`, `islamic`, `adhan`, `salah` — these improve discoverability on pub.dev search and categorization

These changes help improve the [pub.dev score](https://pub.dev/packages/adhan_dart/score) and make the package easier to find.