### PR TITLE
refactor: remove dead code and stale comments

### DIFF
--- a/lib/adhan_dart.dart
+++ b/lib/adhan_dart.dart
@@ -1,4 +1,3 @@
-// original file - not in use
 export 'package:adhan_dart/src/SunnahTimes.dart';
 export 'package:adhan_dart/src/Coordinates.dart';
 export 'package:adhan_dart/src/CalculationMethod.dart';

--- a/lib/src/DateUtils.dart
+++ b/lib/src/DateUtils.dart
@@ -1,5 +1,3 @@
-// import 'package:adhan_dart/src/Astronomical.dart';
-
 DateTime dateByAddingDays(DateTime date, int days) {
   return date.add(Duration(days: days));
 }

--- a/lib/src/PrayerTimes.dart
+++ b/lib/src/PrayerTimes.dart
@@ -55,8 +55,7 @@ class PrayerTimes {
 
     DateTime dateBefore = date.subtract(const Duration(days: 1));
     DateTime dateAfter = date.add(const Duration(days: 1));
-    // todo
-    // print(calculationParameters.ishaAngle);
+
     SolarTime solarTime = SolarTime(date, coordinates);
     SolarTime solarTimeBefore = SolarTime(dateBefore, coordinates);
     SolarTime solarTimeAfter = SolarTime(dateAfter, coordinates);
@@ -88,7 +87,6 @@ class PrayerTimes {
     var tomorrowSolarTime = SolarTime(tomorrow, coordinates);
     DateTime tomorrowSunrise = TimeComponents(tomorrowSolarTime.sunrise)
         .utcDate(tomorrow.year, tomorrow.month, tomorrow.day);
-    // var night = (tomorrowSunrise - sunsetTime) / 1000;
     int night = (tomorrowSunrise.difference(sunsetTime)).inSeconds;
 
     fajrTime = TimeComponents(solarTime.hourAngle(-1 * calculationParameters.fajrAngle, false))
@@ -116,18 +114,6 @@ class PrayerTimes {
         return dateByAddingSeconds(sunriseTime, -nightFraction!.round());
       }
     }
-
-    // TODO?
-    // DateTime safeFajrAfter() {
-    //   if (calculationParameters.method == CalculationMethod.moonsightingCommittee) {
-    //     return Astronomical.seasonAdjustedMorningTwilight(
-    //         coordinates.latitude, dayOfYear(date), date.year, sunriseTime);
-    //   } else {
-    //     var portion = calculationParameters.nightPortions()[fajr];
-    //     nightFraction = portion * night;
-    //     return dateByAddingSeconds(sunriseTime, -nightFraction!.round());
-    //   }
-    // }
 
     if (fajrTime.millisecondsSinceEpoch.isNaN || safeFajr().isAfter(fajrTime)) {
       fajrTime = safeFajr();
@@ -196,7 +182,6 @@ class PrayerTimes {
       }
     }
 
-    // double fajrAdjustment = (calculationParameters.adjustments["fajr"] && 0) + (calculationParameters.methodAdjustments["fajr"] && 0);
     int fajrAdjustment = (calculationParameters.adjustments[Prayer.fajr] ?? 0) +
         (calculationParameters.methodAdjustments[Prayer.fajr] ?? 0);
     int sunriseAdjustment = (calculationParameters.adjustments[Prayer.sunrise] ?? 0) +
@@ -229,9 +214,6 @@ class PrayerTimes {
   ///
   /// [date] - Date/time to check against prayer times
   Prayer currentPrayer({required DateTime date}) {
-    // if (date == null) {
-    //   date = DateTime.now();
-    // }
     if (date.isAfter(isha)) {
       return Prayer.isha;
     } else if (date.isAfter(maghrib)) {

--- a/lib/src/TimeComponents.dart
+++ b/lib/src/TimeComponents.dart
@@ -1,5 +1,3 @@
-// import 'dart:math';
-
 class TimeComponents {
   late int hours;
   late int minutes;


### PR DESCRIPTION
## Summary

- Removes commented-out code and stale TODO comments from multiple files
- Cleans up leftover JavaScript-style comments from the original JS port

## Changes

**PrayerTimes.dart:**
- Removed `// todo` and `// print(calculationParameters.ishaAngle)` debug comment
- Removed commented-out `// var night = (tomorrowSunrise - sunsetTime) / 1000` JS code
- Removed entire commented-out `safeFajrAfter()` function block with `// TODO?`
- Removed commented-out `// double fajrAdjustment = ...` JS-style adjustment line
- Removed commented-out `// if (date == null)` null check in `currentPrayer()`

**DateUtils.dart:**
- Removed `// import 'package:adhan_dart/src/Astronomical.dart'`

**TimeComponents.dart:**
- Removed `// import 'dart:math'`

**adhan_dart.dart:**
- Removed `// original file - not in use` comment

## Test plan

- [ ] Verify `dart analyze` passes with no issues
- [ ] Verify prayer time calculations remain unchanged (no behavioral change)