### PR TITLE
feat: make currentPrayer date optional and add toString

### DIFF
--- a/lib/src/PrayerTimes.dart
+++ b/lib/src/PrayerTimes.dart
@@ -227,11 +227,9 @@ class PrayerTimes {
 
   /// Returns the current prayer for the given date.
   ///
-  /// [date] - Date/time to check against prayer times
-  Prayer currentPrayer({required DateTime date}) {
-    // if (date == null) {
-    //   date = DateTime.now();
-    // }
+  /// [date] - Optional date/time to check against. Defaults to DateTime.now()
+  Prayer currentPrayer({DateTime? date}) {
+    date ??= DateTime.now();
     if (date.isAfter(isha)) {
       return Prayer.isha;
     } else if (date.isAfter(maghrib)) {
@@ -291,5 +289,11 @@ class PrayerTimes {
       case Prayer.fajrAfter:
         return fajrAfter;
     }
+  }
+
+  @override
+  String toString() {
+    return 'PrayerTimes(fajr: $fajr, sunrise: $sunrise, dhuhr: $dhuhr, '
+        'asr: $asr, maghrib: $maghrib, isha: $isha)';
   }
 }


### PR DESCRIPTION
## Summary

- Makes the `date` parameter in `currentPrayer()` optional, defaulting to `DateTime.now()`
- This matches the existing behavior of `nextPrayer()` which already accepts an optional date
- Adds a `toString()` override to PrayerTimes for better debugging output

## Motivation

The `currentPrayer()` method required a `date` parameter while `nextPrayer()` had it as optional. Since the most common use case is checking the current prayer at the current time, making the parameter optional improves usability and API consistency.

Before:
```dart
var current = prayerTimes.currentPrayer(date: DateTime.now()); // required
var next = prayerTimes.nextPrayer(); // optional
```

After:
```dart
var current = prayerTimes.currentPrayer(); // optional, defaults to now
var next = prayerTimes.nextPrayer(); // optional, defaults to now
```

## Test plan

- Verify `currentPrayer()` works without a date parameter
- Verify `currentPrayer(date: someDate)` still works with an explicit date
- Verify `toString()` produces readable output