### PR TITLE
feat: add coordinate range validation assertions

### DIFF
--- a/lib/src/Coordinates.dart
+++ b/lib/src/Coordinates.dart
@@ -8,7 +8,11 @@ class Coordinates {
   final double latitude;
   final double longitude;
 
-  const Coordinates(this.latitude, this.longitude);
+  const Coordinates(this.latitude, this.longitude)
+      : assert(latitude >= -90 && latitude <= 90,
+            'Latitude must be between -90 and 90'),
+        assert(longitude >= -180 && longitude <= 180,
+            'Longitude must be between -180 and 180');
 
   @override
   int get hashCode => latitude.hashCode ^ longitude.hashCode;


### PR DESCRIPTION
## Summary

- Adds debug-mode assertions to the `Coordinates` constructor
- Validates latitude is between -90 and 90 degrees
- Validates longitude is between -180 and 180 degrees
- Preserves the `const` constructor - no breaking changes

## Motivation

Invalid coordinates (e.g., lat=200) can cause silent errors in prayer time calculations, producing incorrect or NaN results. Debug assertions catch these issues early during development while having zero overhead in release builds.

## Test plan

- Verify `Coordinates(35.78, -78.64)` works normally
- Verify `Coordinates(91, 0)` throws AssertionError in debug mode
- Verify `Coordinates(0, 181)` throws AssertionError in debug mode
- Verify `const Coordinates(0, 0)` still works as const