### PR TITLE
feat: add displayName property to Prayer enum

### DIFF
--- a/lib/src/Prayer.dart
+++ b/lib/src/Prayer.dart
@@ -10,12 +10,17 @@
 ///   - ishaBefore (isha prayer of the day before)
 ///   - fajrAfter (fajr prayer of the next day)
 enum Prayer {
-  fajr,
-  sunrise,
-  dhuhr,
-  asr,
-  maghrib,
-  isha,
-  ishaBefore,
-  fajrAfter,
+  fajr('Fajr'),
+  sunrise('Sunrise'),
+  dhuhr('Dhuhr'),
+  asr('Asr'),
+  maghrib('Maghrib'),
+  isha('Isha'),
+  ishaBefore('Isha'),
+  fajrAfter('Fajr');
+
+  /// The display name for this prayer.
+  final String displayName;
+
+  const Prayer(this.displayName);
 }


### PR DESCRIPTION
## Summary

- Converts `Prayer` to an enhanced enum with a `displayName` property
- Returns human-readable names: 'Fajr', 'Sunrise', 'Dhuhr', 'Asr', 'Maghrib', 'Isha'
- `ishaBefore` returns 'Isha' and `fajrAfter` returns 'Fajr' since they represent the same prayers on adjacent days
- No breaking changes - all existing enum values remain the same

## Usage

```dart
var next = prayerTimes.nextPrayer();
print(next.displayName); // e.g., 'Maghrib'
```

## Test plan

- Verify all Prayer enum values have correct display names
- Verify existing code using Prayer enum still works