### PR TITLE
feat: add displayName property to CalculationMethod enum

### DIFF
--- a/lib/src/CalculationMethod.dart
+++ b/lib/src/CalculationMethod.dart
@@ -2,20 +2,25 @@ import 'package:adhan_dart/adhan_dart.dart';
 
 /// Enum holding all the available methods
 enum CalculationMethod {
-  dubai,
-  egyptian,
-  karachi,
-  kuwait,
-  moonsightingCommittee,
-  morocco,
-  muslimWorldLeague,
-  northAmerica,
-  other,
-  qatar,
-  singapore,
-  tehran,
-  turkiye,
-  ummAlQura,
+  dubai('Dubai'),
+  egyptian('Egyptian General Authority of Survey'),
+  karachi('University of Islamic Sciences, Karachi'),
+  kuwait('Kuwait'),
+  moonsightingCommittee('Moonsighting Committee'),
+  morocco('Morocco'),
+  muslimWorldLeague('Muslim World League'),
+  northAmerica('North America (ISNA)'),
+  other('Other'),
+  qatar('Qatar'),
+  singapore('Singapore'),
+  tehran('Tehran'),
+  turkiye('Turkiye (Diyanet)'),
+  ummAlQura('Umm al-Qura');
+
+  /// The display name for this calculation method.
+  final String displayName;
+
+  const CalculationMethod(this.displayName);
 }
 
 /// Class holding the calculation parameters for each method


### PR DESCRIPTION
## Summary

- Converts `CalculationMethod` to an enhanced enum with a `displayName` property
- Each method gets a human-readable name of its organization/origin
- Useful for building settings screens where users select their calculation method

## Usage

```dart
// Building a settings dropdown
for (var method in CalculationMethod.values) {
  print(method.displayName); // e.g., 'Muslim World League'
}
```

## Display names

| Value | Display Name |
|-------|-------------|
| dubai | Dubai |
| egyptian | Egyptian General Authority of Survey |
| karachi | University of Islamic Sciences, Karachi |
| kuwait | Kuwait |
| moonsightingCommittee | Moonsighting Committee |
| morocco | Morocco |
| muslimWorldLeague | Muslim World League |
| northAmerica | North America (ISNA) |
| other | Other |
| qatar | Qatar |
| singapore | Singapore |
| tehran | Tehran |
| turkiye | Turkiye (Diyanet) |
| ummAlQura | Umm al-Qura |

## Test plan

- Verify all CalculationMethod values have correct display names
- Verify existing code using CalculationMethod still works