### PR TITLE
docs: add documentation to HighLatitudeRule enum values

### DIFF
--- a/lib/src/HighLatitudeRule.dart
+++ b/lib/src/HighLatitudeRule.dart
@@ -1,2 +1,19 @@
-/// Used to handle prayer time calculations in high latitude regions
-enum HighLatitudeRule { middleOfTheNight, seventhOfTheNight, twilightAngle }
+/// Used to handle prayer time calculations in high latitude regions.
+///
+/// At high latitudes, Fajr and Isha may not occur because the sun
+/// does not reach the required angle below the horizon. These rules
+/// provide fallback calculations for such cases.
+enum HighLatitudeRule {
+  /// Fajr will never be earlier than the middle of the night and
+  /// Isha will never be later than the middle of the night.
+  middleOfTheNight,
+
+  /// Fajr will never be earlier than the beginning of the last
+  /// seventh of the night and Isha will never be later than the
+  /// end of the first seventh of the night.
+  seventhOfTheNight,
+
+  /// Similar to seventhOfTheNight, but instead of 1/7, the fraction
+  /// of the night used is fajrAngle/60 and ishaAngle/60.
+  twilightAngle,
+}


### PR DESCRIPTION
## Summary

- Adds detailed doc comments to the `HighLatitudeRule` enum and each of its values
- Explains the class-level purpose (handling prayer times in high latitude regions)
- Documents each rule: `middleOfTheNight`, `seventhOfTheNight`, and `twilightAngle`
- Improves IDE hover documentation for developers

## Motivation

The HighLatitudeRule enum had only a one-line class comment and no documentation on individual values. Developers need to understand the differences between rules to choose the appropriate one for their use case.

## Test plan

- No behavioral changes - documentation only