### PR TITLE
feat: add toString override to SunnahTimes

### DIFF
--- a/lib/src/SunnahTimes.dart
+++ b/lib/src/SunnahTimes.dart
@@ -38,4 +38,10 @@ class SunnahTimes {
             prayerTimes.maghrib, (nightDuration.inSeconds * (2 / 3)).floor()),
         precision: precision);
   }
+
+  @override
+  String toString() {
+    return 'SunnahTimes(middleOfTheNight: $middleOfTheNight, '
+        'lastThirdOfTheNight: $lastThirdOfTheNight)';
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `toString()` override to `SunnahTimes` for readable debug output
- Prints both `middleOfTheNight` and `lastThirdOfTheNight` values

## Test plan

- Verify `SunnahTimes.toString()` produces readable output