### PR TITLE
refactor: expose Makkah coordinates and improve Qibla documentation

### DIFF
--- a/lib/src/Qibla.dart
+++ b/lib/src/Qibla.dart
@@ -3,9 +3,11 @@ import 'dart:math';
 import 'package:adhan_dart/src/Coordinates.dart';
 import 'package:adhan_dart/src/MathUtils.dart';
 
-/// A class used to calculate the Qibla direction
-/// returns an angle in degrees that you could place as a mark
-/// on a compass.
+/// A class used to calculate the Qibla direction from a given location.
+///
+/// The Qibla is the direction that Muslims face during prayer, pointing
+/// towards the Kaaba in Makkah, Saudi Arabia.
+///
 /// Example:
 /// ```dart
 /// final coordinates = Coordinates(-39.231, 12.412);
@@ -13,18 +15,18 @@ import 'package:adhan_dart/src/MathUtils.dart';
 /// print(qiblaAngle); // prints a value of 28.015999604802534
 /// ```
 class Qibla {
-  /// The method used to calculate the Qibla direction
-  /// returns an angle in degrees that you could place as a mark
-  /// on a compass.
+  static const Coordinates makkah = Coordinates(21.4225241, 39.8261818);
+
+  /// Calculates the Qibla direction from the given coordinates.
+  ///
+  /// Returns the angle in degrees from North (clockwise).
+  ///
   /// Example:
   /// ```dart
-  /// final coordinates = Coordinates(-39.231, 12.412);
-  /// final qiblaAngle = Qibla.qibla(coordinates);
-  /// print(qiblaAngle); // prints a value of 28.015999604802534
+  /// final coordinates = Coordinates(35.78056, -78.6389);
+  /// final angle = Qibla.qibla(coordinates);
   /// ```
   static double qibla(Coordinates coordinates) {
-    Coordinates makkah = const Coordinates(21.4225241, 39.8261818);
-
     // Equation from "Spherical Trigonometry For the use of colleges and schools" page 50
     double term1 = (sin(degreesToRadians(makkah.longitude) -
         degreesToRadians(coordinates.longitude)));


### PR DESCRIPTION
## Summary

- Extracts the Makkah coordinates as a public static constant `Qibla.makkah`
- Improves class-level and method-level documentation
- Adds explanation that the return value is degrees from North (clockwise)
- No behavioral changes

## Motivation

The Makkah coordinates (21.4225241, 39.8261818) were previously hardcoded inside the `qibla()` method. Exposing them as `Qibla.makkah` allows consumers to reference the Kaaba coordinates for other purposes (e.g., distance calculation, map markers).

## Test plan

- Verify `Qibla.makkah` returns the correct Makkah coordinates
- Verify `Qibla.qibla()` still returns the same values as before