### PR TITLE
feat: add toString override to CalculationParameters

### DIFF
--- a/lib/src/CalculationParameters.dart
+++ b/lib/src/CalculationParameters.dart
@@ -85,4 +85,11 @@ class CalculationParameters {
         throw ('Invalid high latitude rule found when attempting to compute night portions: $highLatitudeRule');
     }
   }
+
+  @override
+  String toString() {
+    return 'CalculationParameters(method: $method, fajrAngle: $fajrAngle, '
+        'ishaAngle: $ishaAngle, ishaInterval: $ishaInterval, '
+        'maghribAngle: $maghribAngle, madhab: $madhab)';
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `toString()` override to `CalculationParameters` for readable debug output
- Shows method, fajrAngle, ishaAngle, ishaInterval, maghribAngle, and madhab

## Example output

```
CalculationParameters(method: CalculationMethod.muslimWorldLeague, fajrAngle: 18.0, ishaAngle: 17.0, ishaInterval: 0, maghribAngle: null, madhab: Madhab.shafi)
```

## Test plan

- Verify toString() produces readable output for various calculation methods